### PR TITLE
fix title top border to fit in

### DIFF
--- a/src/Header/Header.styles.js
+++ b/src/Header/Header.styles.js
@@ -10,6 +10,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     width: 60,
+    borderColor: '#fff',
+    borderTopWidth: 1,
   },
   columns: {
     flex: 1,


### PR DESCRIPTION
<img width="359" alt="Screen Shot 2019-07-21 at 2 34 39 AM" src="https://user-images.githubusercontent.com/13645032/61581990-40918700-ab60-11e9-8afc-c384e80f2215.png">

juillet 2019 doesn't fit with the others.