### PR TITLE
Add goToDate() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
 # react-native-week-view
 
 ![weekView](images/gif.gif)
+
+
+## Basic Usage
+```js
+import WeekView from 'react-native-week-view';
+
+const myEvents = [
+  // ...
+];
+
+const MyComponent = () => (
+  <WeekView
+    events={myEvents}
+    selectedDate={new Date()}
+    numberOfDays={7}
+  />
+);
+
+```
+
 ## Props
-* **`events`** _(Array)_ - Events to display
+* **`events`** _(Array)_ - Events to display, in `Event Object` format (see below)
 * **`onEventPress`** _(Function)_ - Callback when event item is clicked
 * **`numberOfDays`** _(Number)_ - Set number of days to show in view, can be `1`, `3`, `5`, `7`.
 * **`formatDateHeader`** _(String)_ - Format for dates of header, default is `MMM D`
@@ -10,7 +30,7 @@
 * **`onSwipeNext`** _(Function)_ - Callback when calendar is swiped to next week/days
 * **`onSwipePrev`** _(Function)_ - Callback when calendar is swiped to previous week/days
 * **`locale`** _(String)_ - locale for the header, there's a `addLocale` function to add cusomized locale. Default is `en`.
-* **`showTitle`** _(Boolean)_ - show/hide the title (the selected month and year). Default is `true`. 
+* **`showTitle`** _(Boolean)_ - show/hide the title (the selected month and year). Default is `true`.
 * **`headerStyle`** _(Object)_ - custom styles for header container. Example: `{ backgroundColor: '#4286f4', color: '#fff', borderColor: '#fff' }`
 * **`headerTextStyle`** _(Object)_ - custom styles for text inside header. Includes day names and title (month)
 * **`hourTextStyle`** _(Object)_ - custom styles for text displaying hours in the left.
@@ -36,6 +56,19 @@
   // ... more properties if needed,
 }
 ```
+
+## Methods
+
+To use the component methods save a reference to it:
+```js
+<WeekView
+  // ... other props
+  ref={(ref) => { this.weekViewRef = ref; }}
+/>
+```
+
+* **`goToDate(date, animated = true)`**: when called, the component navigates to a custom date. Note: if the target date has not been rendered before, there may be a delay on the animation. See [this issue](https://github.com/hoangnm/react-native-week-view/issues/54) for details.
+
 
 ## Custom `EventComponent`
 The component will be rendered inside a `TouchableOpacity`, which has the background color set to `event.color`, and is placed with absolute position in the grid. The component receives two props:
@@ -63,7 +96,7 @@ const MyEventComponent = ({ event, position }) => (
 There's a `addLocale` function to add customized locale for the component. The component depends on `momentjs`, you can refer to https://momentjs.com/docs/#/customization/ for more information.
 
 Example:
-```
+```js
 export WeekView, { addLocale } from 'react-native-week-view';
 // add customized localed before using locale prop.
 addLocale('fr', {
@@ -73,6 +106,7 @@ addLocale('fr', {
   weekdaysShort: 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
 });
 ```
+
 ## TODO
 - [x] allow to swipe between weeks or days.
 - [x] header should be swipeable with columns.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const MyComponent = () => (
 * **`onEventPress`** _(Function)_ - Callback when event item is clicked
 * **`numberOfDays`** _(Number)_ - Set number of days to show in view, can be `1`, `3`, `5`, `7`.
 * **`formatDateHeader`** _(String)_ - Format for dates of header, default is `MMM D`
-* **`selectedDate`** _(Date)_ - Intial date to show week/days in view
+* **`selectedDate`** _(Date)_ - Intial date to show week/days in the view. Note: changing this prop will not have any effect in the displayed date; to actually change the date being displayed, use the `goToDate()` method, see below.
 * **`onSwipeNext`** _(Function)_ - Callback when calendar is swiped to next week/days
 * **`onSwipePrev`** _(Function)_ - Callback when calendar is swiped to previous week/days
 * **`locale`** _(String)_ - locale for the header, there's a `addLocale` function to add cusomized locale. Default is `en`.

--- a/example/App.js
+++ b/example/App.js
@@ -69,6 +69,9 @@ class App extends React.Component {
         <StatusBar barStyle="dark-content" />
         <SafeAreaView style={styles.container}>
           <WeekView
+            ref={r => {
+              this.componentRef = r;
+            }}
             events={events}
             selectedDate={selectedDate}
             numberOfDays={3}

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -211,7 +211,7 @@ export default class WeekView extends Component {
         newStateCallback = () => setTimeout(scrollToCurrentIndex, 0);
       } else if (
         movedPages > 0 &&
-        newPage > this.state.initialDates.length - this.pageOffset
+        newPage >= this.state.initialDates.length - this.pageOffset
       ) {
         this.appendPagesInPlace(initialDates, 1);
 

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -36,13 +36,16 @@ export default class WeekView extends Component {
     this.pageOffset = 2;
     this.currentPageIndex = this.pageOffset;
     this.eventsGridScrollX = new Animated.Value(0);
+
+    const initialDates = this.calculatePagesDates(
+      props.selectedDate,
+      props.numberOfDays,
+      props.prependMostRecent,
+    );
     this.state = {
-      currentMoment: props.selectedDate,
-      initialDates: this.calculatePagesDates(
-        props.selectedDate,
-        props.numberOfDays,
-        props.prependMostRecent,
-      ),
+      // currentMoment should always be the first date of the current page
+      currentMoment: moment(initialDates[this.currentPageIndex]).toDate(),
+      initialDates,
     };
 
     setLocale(props.locale);
@@ -89,19 +92,96 @@ export default class WeekView extends Component {
     }
   };
 
+  getSignToTheFuture = () => {
+    const { prependMostRecent } = this.props;
+
+    const daySignToTheFuture = prependMostRecent ? -1 : 1;
+    return daySignToTheFuture;
+  };
+
+  prependPagesInPlace = (initialDates, nPages) => {
+    const { numberOfDays } = this.props;
+    const daySignToTheFuture = this.getSignToTheFuture();
+
+    const first = initialDates[0];
+    const daySignToThePast = daySignToTheFuture * -1;
+    const addDays = numberOfDays * daySignToThePast;
+    for (let i = 1; i <= nPages; i += 1) {
+      const initialDate = moment(first).add(addDays * i, 'd');
+      initialDates.unshift(initialDate.format(DATE_STR_FORMAT));
+    }
+  };
+
+  appendPagesInPlace = (initialDates, nPages) => {
+    const { numberOfDays } = this.props;
+    const daySignToTheFuture = this.getSignToTheFuture();
+
+    const latest = initialDates[initialDates.length - 1];
+    const addDays = numberOfDays * daySignToTheFuture;
+    for (let i = 1; i <= nPages; i += 1) {
+      const initialDate = moment(latest).add(addDays * i, 'd');
+      initialDates.push(initialDate.format(DATE_STR_FORMAT));
+    }
+  };
+
+  goToDate = (targetDate, animated = true) => {
+    const { initialDates } = this.state;
+    const { numberOfDays } = this.props;
+
+    const currentDate = initialDates[this.currentPageIndex];
+    const deltaDay = moment(targetDate).diff(currentDate, 'day');
+    const deltaIndex = Math.floor(deltaDay / numberOfDays);
+    const signToTheFuture = this.getSignToTheFuture();
+    let targetIndex = this.currentPageIndex + deltaIndex * signToTheFuture;
+
+    if (targetIndex === this.currentPageIndex) {
+      return;
+    }
+
+    const scrollTo = (moveToIndex) => {
+      this.eventsGrid.scrollToIndex({
+        index: moveToIndex,
+        animated,
+      });
+      this.currentPageIndex = moveToIndex;
+    };
+
+    const newState = {};
+    let newStateCallback = () => {};
+
+    const lastViewablePage = initialDates.length - this.pageOffset;
+    if (targetIndex < this.pageOffset) {
+      const nPages = this.pageOffset - targetIndex;
+      this.prependPagesInPlace(initialDates, nPages);
+
+      targetIndex = this.pageOffset;
+
+      newState.initialDates = [...initialDates];
+      newStateCallback = () => setTimeout(() => scrollTo(targetIndex), 0);
+    } else if (targetIndex > lastViewablePage) {
+      const nPages = targetIndex - lastViewablePage;
+      this.appendPagesInPlace(initialDates, nPages);
+
+      targetIndex = initialDates.length - this.pageOffset;
+
+      newState.initialDates = [...initialDates];
+      newStateCallback = () => setTimeout(() => scrollTo(targetIndex), 0);
+    } else {
+      scrollTo(targetIndex);
+    }
+
+    newState.currentMoment = moment(initialDates[targetIndex]).toDate();
+    this.setState(newState, newStateCallback);
+  };
+
   scrollEnded = (event) => {
     const {
       nativeEvent: { contentOffset, contentSize },
     } = event;
     const { x: position } = contentOffset;
     const { width: innerWidth } = contentSize;
-    const {
-      onSwipePrev,
-      onSwipeNext,
-      numberOfDays,
-      prependMostRecent,
-    } = this.props;
-    const { currentMoment, initialDates } = this.state;
+    const { onSwipePrev, onSwipeNext } = this.props;
+    const { initialDates } = this.state;
 
     const newPage = Math.round((position / innerWidth) * initialDates.length);
     const movedPages = newPage - this.currentPageIndex;
@@ -112,41 +192,33 @@ export default class WeekView extends Component {
     }
 
     InteractionManager.runAfterInteractions(() => {
-      const daySignToTheFuture = prependMostRecent ? -1 : 1;
-      const newMoment = moment(currentMoment)
-        .add(movedPages * numberOfDays * daySignToTheFuture, 'd')
-        .toDate();
-
+      const newMoment = moment(initialDates[this.currentPageIndex]).toDate();
       const newState = {
         currentMoment: newMoment,
       };
+      let newStateCallback = () => {};
 
       if (movedPages < 0 && newPage < this.pageOffset) {
-        const first = initialDates[0];
-        const daySignToThePast = daySignToTheFuture * -1;
-        const addDays = numberOfDays * daySignToThePast;
-        const initialDate = moment(first).add(addDays, 'd');
-        initialDates.unshift(initialDate.format(DATE_STR_FORMAT));
+        this.prependPagesInPlace(initialDates, 1);
         this.currentPageIndex += 1;
-        this.eventsGrid.scrollToIndex({
-          index: this.currentPageIndex,
-          animated: false,
-        });
 
         newState.initialDates = [...initialDates];
+        const scrollToCurrentIndex = () =>
+          this.eventsGrid.scrollToIndex({
+            index: this.currentPageIndex,
+            animated: false,
+          });
+        newStateCallback = () => setTimeout(scrollToCurrentIndex, 0);
       } else if (
         movedPages > 0 &&
         newPage > this.state.initialDates.length - this.pageOffset
       ) {
-        const latest = initialDates[initialDates.length - 1];
-        const addDays = numberOfDays * daySignToTheFuture;
-        const initialDate = moment(latest).add(addDays, 'd');
-        initialDates.push(initialDate.format(DATE_STR_FORMAT));
+        this.appendPagesInPlace(initialDates, 1);
 
         newState.initialDates = [...initialDates];
       }
 
-      this.setState(newState);
+      this.setState(newState, newStateCallback);
 
       if (movedPages < 0) {
         onSwipePrev && onSwipePrev(newMoment);


### PR DESCRIPTION
Add method to navigate to a specific date, fixes #54  

Notes:
* This is a breaking change (to move to a date). Maybe we could create a changelog documenting this?
* There is a slight hack with the `setTimeout(..., 0)` method. This is needed so the child `VirtualizedList` gets updated first, and only then the `this.eventsGrid.scrollToIndex()` gets called.
  - If the `this.eventsGrid.scrollToIndex()` function is called first, the new pages are not rendered yet
  - I could not make it work with other callback managers, such as `InteractionsManager.runAfterInteractions`
* The code got a little messy, if you have any suggestions to improve it let me know!