### PR TITLE
Fix isoweekday issue

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -32,7 +32,7 @@ export const calculateDaysArray = (date, numberOfDays, rightToLeft) => {
   let initial = 0;
   if (numberOfDays === 7) {
     initial = 1;
-    initial -= moment().isoWeekday();
+    initial -= moment(date).isoWeekday();
   }
   for (let i = initial; i < numberOfDays + initial; i += 1) {
     const currentDate = moment(date).add(i, 'd');


### PR DESCRIPTION
Fixes #55

Now, when `numberOfDays === 7`, the week always starts in a monday, independent of the `selectedDate` passed