### PR TITLE
Don't use headerStyle.color

### DIFF
--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -19,13 +19,7 @@ const getDayTextStyles = (numberOfDays) => {
 const Column = ({ column, numberOfDays, format, style, textStyle }) => {
   return (
     <View style={[styles.column, style]}>
-      <Text
-        style={[
-          { color: style.color },
-          getDayTextStyles(numberOfDays),
-          textStyle,
-        ]}
-      >
+      <Text style={[getDayTextStyles(numberOfDays), textStyle]}>
         {getFormattedDate(column, format)}
       </Text>
     </View>

--- a/src/Title/Title.js
+++ b/src/Title/Title.js
@@ -19,7 +19,6 @@ const Title = ({ style, showTitle, numberOfDays, selectedDate, textStyle }) => {
         <Text
           style={[
             {
-              color: style.color,
               fontSize: getFontSizeHeader(numberOfDays),
               textAlign: 'center',
             },


### PR DESCRIPTION
Fixes #64 

This is a (small) breaking change, as the text color should not be set in the `headerStyle` prop, but only in the `headerTextStyle` prop. (Only users setting the text-color via `headerStyle.color` would be affected)