### PR TITLE
Fix initialDates shift bug

### DIFF
--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -242,8 +242,13 @@ export default class WeekView extends Component {
 
   calculatePagesDates = (currentMoment, numberOfDays, prependMostRecent) => {
     const initialDates = [];
+    const centralDate = moment(currentMoment);
+    if (numberOfDays === 7) {
+      // Start week on monday
+      centralDate.startOf('isoWeek');
+    }
     for (let i = -this.pageOffset; i <= this.pageOffset; i += 1) {
-      const initialDate = moment(currentMoment).add(numberOfDays * i, 'd');
+      const initialDate = moment(centralDate).add(numberOfDays * i, 'd');
       initialDates.push(initialDate.format(DATE_STR_FORMAT));
     }
     return prependMostRecent ? initialDates.reverse() : initialDates;

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,12 +29,7 @@ export const getCurrentMonth = (date) => {
 
 export const calculateDaysArray = (date, numberOfDays, rightToLeft) => {
   const dates = [];
-  let initial = 0;
-  if (numberOfDays === 7) {
-    initial = 1;
-    initial -= moment(date).isoWeekday();
-  }
-  for (let i = initial; i < numberOfDays + initial; i += 1) {
+  for (let i = 0; i < numberOfDays; i += 1) {
     const currentDate = moment(date).add(i, 'd');
     dates.push(currentDate);
   }


### PR DESCRIPTION
Fixes #76 

* Now the `initialDates` array contains the correct initial dates from each page,  which did not occur before if `numberOfDays` was 7
* Now the "decision" to start a week on Mondays gets relegated to the `calculatePagesDates()` method, and `calculateDaysArray` is simplified