### PR TITLE
Fix goToDate off-by-one bug

### DIFF
--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -128,8 +128,8 @@ export default class WeekView extends Component {
     const { initialDates } = this.state;
     const { numberOfDays } = this.props;
 
-    const currentDate = initialDates[this.currentPageIndex];
-    const deltaDay = moment(targetDate).diff(currentDate, 'day');
+    const currentDate = moment(initialDates[this.currentPageIndex]).startOf('day');
+    const deltaDay = moment(targetDate).startOf('day').diff(currentDate, 'day');
     const deltaIndex = Math.floor(deltaDay / numberOfDays);
     const signToTheFuture = this.getSignToTheFuture();
     let targetIndex = this.currentPageIndex + deltaIndex * signToTheFuture;


### PR DESCRIPTION
Fixes #93 

* This bug occured when `numberOfDays===1` only 
* In `goToDate()`, when the dates are compared (i.e. `moment.diff`), the difference may be slightly less than 1 day (e.g. 23h 59min), and gets truncated down to 0 days --> it moves one day less than what it should move.
* Now, the dates are moved to the start of the day (`startOf('day')`) to be compared properly, and avoid truncation