### PR TITLE
Feature: add onGridLongPress prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ const MyComponent = () => (
   * `pressEvent` _(Object)_ - object passed by the [TouchableWithoutFeedback.onPress() method](https://reactnative.dev/docs/touchablewithoutfeedback#onpress) (and not an event object as defined below)
   * `startHour` _(Number)_ - hour clicked (as integer)
   * `date` _(Date)_ - date object indicating day clicked (the hour is not relevant)
+* **`onGridLongPress`** _(Function)_ - Callback when the grid view is long-pressed. Same signature as `onGridClick`
 * **`EventComponent`** _(React.Component)_ - Custom component rendered inside an event. By default, is a `Text` with the `event.description`. See [sub-section below](#custom-eventcomponent) for details on the component.
 * **`showNowLine`** _(Boolean)_ - If `true`, displays a line indicating the time right now. Defaults to `false`.
 * **`nowLineColor`** _(String)_ - Color used for the now-line. Defaults to a red `#e53935`.

--- a/src/Events/Events.js
+++ b/src/Events/Events.js
@@ -183,9 +183,10 @@ class Events extends PureComponent {
     },
   );
 
-  onGridClick = (event, dayIndex) => {
-    const { initialDate, onGridClick } = this.props;
-    if (!onGridClick) {
+  onGridTouch = (event, dayIndex, longPress) => {
+    const { initialDate, onGridClick, onGridLongPress } = this.props;
+    const callback = longPress ? onGridLongPress : onGridClick;
+    if (!callback) {
       return;
     }
     const { locationY } = event.nativeEvent;
@@ -193,7 +194,7 @@ class Events extends PureComponent {
 
     const date = moment(initialDate).add(dayIndex, 'day').toDate();
 
-    onGridClick(event, hour, date);
+    callback(event, hour, date);
   };
 
   isToday = (dayIndex) => {
@@ -240,7 +241,8 @@ class Events extends PureComponent {
         <View style={styles.events}>
           {totalEvents.map((eventsInSection, dayIndex) => (
             <TouchableWithoutFeedback
-              onPress={(e) => this.onGridClick(e, dayIndex)}
+              onPress={(e) => this.onGridTouch(e, dayIndex, false)}
+              onLongPress={(e) => this.onGridTouch(e, dayIndex, true)}
               key={dayIndex}
             >
               <View style={styles.event}>
@@ -280,6 +282,7 @@ Events.propTypes = {
   times: PropTypes.arrayOf(PropTypes.string).isRequired,
   onEventPress: PropTypes.func,
   onGridClick: PropTypes.func,
+  onGridLongPress: PropTypes.func,
   eventContainerStyle: PropTypes.object,
   EventComponent: PropTypes.elementType,
   rightToLeft: PropTypes.bool,

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -337,6 +337,7 @@ export default class WeekView extends Component {
       timeStep,
       formatTimeLabel,
       onGridClick,
+      onGridLongPress,
       EventComponent,
       prependMostRecent,
       rightToLeft,
@@ -415,6 +416,7 @@ export default class WeekView extends Component {
                     numberOfDays={numberOfDays}
                     onEventPress={onEventPress}
                     onGridClick={onGridClick}
+                    onGridLongPress={onGridLongPress}
                     hoursInDisplay={hoursInDisplay}
                     timeStep={timeStep}
                     EventComponent={EventComponent}
@@ -459,6 +461,7 @@ WeekView.propTypes = {
   onSwipePrev: PropTypes.func,
   onEventPress: PropTypes.func,
   onGridClick: PropTypes.func,
+  onGridLongPress: PropTypes.func,
   headerStyle: PropTypes.object,
   headerTextStyle: PropTypes.object,
   hourTextStyle: PropTypes.object,


### PR DESCRIPTION
* Added `onGridLongPress` prop, to allow different user-interactions with the grid
* I realize the name is different than `onGridClick` (click vs press). I think in mobile "press" sounds more natural. We could rename `onGridClick` to `onGridPress` in a future (breaking) version