### PR TITLE
Feature: add TodayHeaderComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ const MyComponent = () => (
   * `startHour` _(Number)_ - hour clicked (as integer)
   * `date` _(Date)_ - date object indicating day clicked (the hour is not relevant)
 * **`EventComponent`** _(React.Component)_ - Custom component rendered inside an event. By default, is a `Text` with the `event.description`. See [sub-section below](#custom-eventcomponent) for details on the component.
+* **`TodayHeaderComponent`** _(React.Component)_ - Custom component to highlight today in the header (by default, *today* looks the same than every day). See details in [sub-section below](#custom-todaycomponent)
 * **`showNowLine`** _(Boolean)_ - If `true`, displays a line indicating the time right now. Defaults to `false`.
 * **`nowLineColor`** _(String)_ - Color used for the now-line. Defaults to a red `#e53935`.
 * **`rightToLeft`** _(Boolean)_ - If `true`, render older days to the right and more recent days to the left.
@@ -107,6 +108,25 @@ const MyEventComponent = ({ event, position }) => (
 <WeekView
   // ... other props
   EventComponent={MyEventComponent}
+/>
+```
+
+
+### Custom TodayComponent
+Use this prop to highlight today in the header, by rendering it differently from the other days. The component `TodayHeaderComponent` receives these props:
+* `date` _(moment Date)_ - moment date object containing today's date.
+* `formattedDate` _(String)_ - day formatted according to `formatDateHeader`, e.g. `"Mon 3"`.
+* `textStyle` _(Object)_ - text style used for every day.
+
+For example, to highlight today with a bold font:
+```js
+const MyTodayComponent = ({ formattedDate, textStyle }) => (
+  <Text style={[textStyle, { fontWeight: 'bold' }]}>{formattedDate}</Text>
+);
+
+<WeekView
+  // ... other props
+  TodayHeaderComponent={MyTodayComponent}
 />
 ```
 

--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Text, View } from 'react-native';
+import moment from 'moment';
 
 import {
   getFormattedDate,
@@ -16,17 +17,41 @@ const getDayTextStyles = (numberOfDays) => {
   };
 };
 
-const Column = ({ column, numberOfDays, format, style, textStyle }) => {
+const Column = ({
+  column,
+  numberOfDays,
+  format,
+  style,
+  textStyle,
+  TodayComponent,
+}) => {
+  const formattedDate = getFormattedDate(column, format);
+  const useTodayComponent = TodayComponent && moment().isSame(column, 'days');
+  const fullTextStyle = [getDayTextStyles(numberOfDays), textStyle];
+
   return (
     <View style={[styles.column, style]}>
-      <Text style={[getDayTextStyles(numberOfDays), textStyle]}>
-        {getFormattedDate(column, format)}
-      </Text>
+      {useTodayComponent ? (
+        <TodayComponent
+          date={column}
+          formattedDate={formattedDate}
+          textStyle={fullTextStyle}
+        />
+      ) : (
+        <Text style={fullTextStyle}>{formattedDate}</Text>
+      )}
     </View>
   );
 };
 
-const Columns = ({ columns, numberOfDays, format, style, textStyle }) => {
+const Columns = ({
+  columns,
+  numberOfDays,
+  format,
+  style,
+  textStyle,
+  TodayComponent,
+}) => {
   return (
     <View style={styles.columns}>
       {columns.map((column) => {
@@ -38,6 +63,7 @@ const Columns = ({ columns, numberOfDays, format, style, textStyle }) => {
             column={column}
             numberOfDays={numberOfDays}
             format={format}
+            TodayComponent={TodayComponent}
           />
         );
       })}
@@ -51,6 +77,7 @@ const WeekViewHeader = ({
   formatDate,
   style,
   textStyle,
+  TodayComponent,
   rightToLeft,
 }) => {
   const columns = calculateDaysArray(initialDate, numberOfDays, rightToLeft);
@@ -63,6 +90,7 @@ const WeekViewHeader = ({
           numberOfDays={numberOfDays}
           style={style}
           textStyle={textStyle}
+          TodayComponent={TodayComponent}
         />
       )}
     </View>
@@ -76,6 +104,7 @@ WeekViewHeader.propTypes = {
   style: PropTypes.object,
   textStyle: PropTypes.object,
   rightToLeft: PropTypes.bool,
+  TodayComponent: PropTypes.elementType,
 };
 
 WeekViewHeader.defaultProps = {

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -330,6 +330,7 @@ export default class WeekView extends Component {
       headerTextStyle,
       hourTextStyle,
       eventContainerStyle,
+      TodayHeaderComponent,
       formatDateHeader,
       onEventPress,
       events,
@@ -380,6 +381,7 @@ export default class WeekView extends Component {
                   <Header
                     style={headerStyle}
                     textStyle={headerTextStyle}
+                    TodayComponent={TodayHeaderComponent}
                     formatDate={formatDateHeader}
                     initialDate={item}
                     numberOfDays={numberOfDays}
@@ -470,6 +472,7 @@ WeekView.propTypes = {
   formatTimeLabel: PropTypes.string,
   startHour: PropTypes.number,
   EventComponent: PropTypes.elementType,
+  TodayHeaderComponent: PropTypes.elementType,
   showTitle: PropTypes.bool,
   rightToLeft: PropTypes.bool,
   fixedHorizontally: PropTypes.bool,


### PR DESCRIPTION
Fixes #104

Add `TodayHeaderComponent` prop, to allow highlighting today in the header.

I was not sure on how to visually highlight today in the header, so with this prop the developer can fully customize how it looks. Examples: bold the font, add a rounded box, change the background color, etc.