### PR TITLE
Fix onMomentumScrollEnd called twice

### DIFF
--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -190,7 +190,17 @@ export default class WeekView extends Component {
     this.setState(newState, newStateCallback);
   };
 
+  scrollBegun = () => {
+    this.isScrollingHorizontal = true;
+  };
+
   scrollEnded = (event) => {
+    if (!this.isScrollingHorizontal) {
+      // Ensure the callback is called only once
+      return;
+    }
+    this.isScrollingHorizontal = false;
+
     const {
       nativeEvent: { contentOffset, contentSize },
     } = event;
@@ -428,6 +438,7 @@ export default class WeekView extends Component {
               horizontal
               pagingEnabled
               inverted={horizontalInverted}
+              onMomentumScrollBegin={this.scrollBegun}
               onMomentumScrollEnd={this.scrollEnded}
               scrollEventThrottle={32}
               onScroll={Animated.event(


### PR DESCRIPTION
Fixes #109

* react-native bug affecting 0.64.0, `VirtualizedList` calls `onMomentumScrollEnd` more than once sometimes
* This PR is a workaround, the callback gets called only once