### PR TITLE
Add weekStartsOn prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ const MyComponent = () => (
 * **`events`** _(Array)_ - Events to display, in `Event Object` format (see [sub-section below](#event-object))
 * **`onEventPress`** _(Function)_ - Callback when event item is clicked
 * **`numberOfDays`** _(Number)_ - Set number of days to show in view, can be `1`, `3`, `5`, `7`.
+* **`weekStartsOn`** _(Number)_ - Day to start the week (0 is Sunday, 1 is Monday, and so on). Defaults to 1. Only useful when `numberOfDays === 7` or `fixedHorizontally` is true.
 * **`formatDateHeader`** _(String)_ - Format for dates of header, default is `MMM D`
 * **`selectedDate`** _(Date)_ - Intial date to show week/days in the view. Note: changing this prop will not have any effect in the displayed date; to actually change the date being displayed, use the `goToDate()` method, see below.
 * **`onSwipeNext`** _(Function)_ - Callback when calendar is swiped to next week/days

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -39,6 +39,7 @@ export default class WeekView extends Component {
     const initialDates = this.calculatePagesDates(
       props.selectedDate,
       props.numberOfDays,
+      props.weekStartsOn,
       props.prependMostRecent,
       props.fixedHorizontally,
     );
@@ -259,14 +260,18 @@ export default class WeekView extends Component {
   calculatePagesDates = (
     currentMoment,
     numberOfDays,
+    weekStartsOn,
     prependMostRecent,
     fixedHorizontally,
   ) => {
     const initialDates = [];
     const centralDate = moment(currentMoment);
     if (numberOfDays === 7 || fixedHorizontally) {
-      // Start week on monday
-      centralDate.startOf('isoWeek');
+      centralDate.subtract(
+        // Ensure centralDate is before currentMoment
+        (centralDate.day() + 7 - weekStartsOn) % 7,
+        'days',
+      );
     }
     for (let i = -this.pageOffset; i <= this.pageOffset; i += 1) {
       const initialDate = moment(centralDate).add(numberOfDays * i, 'd');
@@ -455,6 +460,7 @@ WeekView.propTypes = {
   events: PropTypes.arrayOf(Event.propTypes.event),
   formatDateHeader: PropTypes.string,
   numberOfDays: PropTypes.oneOf(availableNumberOfDays).isRequired,
+  weekStartsOn: PropTypes.number,
   onSwipeNext: PropTypes.func,
   onSwipePrev: PropTypes.func,
   onEventPress: PropTypes.func,
@@ -482,6 +488,7 @@ WeekView.defaultProps = {
   events: [],
   locale: 'en',
   hoursInDisplay: 6,
+  weekStartsOn: 1,
   timeStep: 60,
   formatTimeLabel: 'H:mm',
   startHour: 0,


### PR DESCRIPTION
Fixes #119 

Add prop `weekStartsOn` to set initial day of the week (e.g. sunday, monday or any other day)