### PR TITLE
Add precision up to seconds in onGrid callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const MyComponent = () => (
 * **`onGridClick`** _(Function)_ - Callback when the grid view is clicked, signature: `(pressEvent, startHour, date) => {}`.
   * `pressEvent` _(Object)_ - object passed by the [TouchableWithoutFeedback.onPress() method](https://reactnative.dev/docs/touchablewithoutfeedback#onpress) (and not an event object as defined below)
   * `startHour` _(Number)_ - hour clicked (as integer)
-  * `date` _(Date)_ - date object indicating day clicked (the hour is not relevant)
+  * `date` _(Date)_ - date object indicating day and time pressed with precision up to seconds (hours, minutes and seconds). Notice: finger pressing is usually not so precise.
 * **`onGridLongPress`** _(Function)_ - Callback when the grid view is long-pressed. Same signature as `onGridClick`
 * **`EventComponent`** _(React.Component)_ - Custom component rendered inside an event. By default, is a `Text` with the `event.description`. See [sub-section below](#custom-eventcomponent) for details on the component.
 * **`TodayHeaderComponent`** _(React.Component)_ - Custom component to highlight today in the header (by default, *today* looks the same than every day). See details in [sub-section below](#custom-todaycomponent)

--- a/example/App.js
+++ b/example/App.js
@@ -68,7 +68,7 @@ const sampleFixedEvents = [
 ];
 
 // For debugging purposes
-const showFixedComponent = true;
+const showFixedComponent = false;
 
 const MyRefreshComponent = ({style}) => (
   // Just an example
@@ -89,8 +89,14 @@ class App extends React.Component {
   };
 
   onGridClick = (event, startHour, date) => {
-    const dateStr = date.toISOString().split('T')[0];
-    Alert.alert(`Date: ${dateStr}\nStart hour: ${startHour}`);
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1; // zero-based
+    const day = date.getDate();
+    const hour = date.getHours();
+    const minutes = date.getMinutes();
+    const seconds = date.getSeconds();
+
+    Alert.alert(`${year}-${month}-${day} ${hour}:${minutes}:${seconds}`);
   };
 
   onDragEvent = (event, newStartDate, newEndDate) => {

--- a/src/Events/Events.js
+++ b/src/Events/Events.js
@@ -192,9 +192,21 @@ class Events extends PureComponent {
       return;
     }
     const { locationY } = event.nativeEvent;
-    const hour = Math.floor(this.yToHour(locationY - CONTENT_OFFSET));
 
-    const date = moment(initialDate).add(dayIndex, 'day').toDate();
+    // WithDec === with decimals. // e.g. hours 10.5 === 10:30am
+    const hoursWDec = this.yToHour(locationY - CONTENT_OFFSET);
+    const minutesWDec = (hoursWDec - parseInt(hoursWDec)) * 60;
+    const seconds = Math.floor((minutesWDec - parseInt(minutesWDec)) * 60);
+
+    const hour = Math.floor(hoursWDec);
+    const minutes = Math.floor(minutesWDec);
+
+    const date = moment(initialDate)
+      .add(dayIndex, 'day')
+      .hours(hour)
+      .minutes(minutes)
+      .seconds(seconds)
+      .toDate();
 
     callback(event, hour, date);
   };


### PR DESCRIPTION
Fixes #148

* The `startHour` argument is redundant now (i.e. `=== date.getHours()`), I'd say we can remove it in a future 1.x release? (would be a breaking change)