### PR TITLE
Feature: edit events by dragging bottom border

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,11 +233,12 @@ class MyComponent extends React.Component {
   };
 
   // (3) Edit event
-  handleEditEventEndDate = (event, newEndDate) => {
+  handleEditEventEndDate = (oldEvent, newEndDate) => {
     // Update event in the DB
+    const event = this.state.events.find(e => e.id === oldEvent.id);
     this.setState({
       events: [
-        ...this.state.events.filter(e => e.id !== event.id),
+        ...this.state.events.filter(e => e.id !== oldEvent.id),
         {
           ...event,
           endDate: newEndDate,

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The week view component for react-native.
 ## Key features
 
 * Supported in Android and iOS
-* Many user interactions supported: **drag and drop events**, swipe through pages, event press and long-press, grid press and long-press
+* Many user interactions supported: **drag and drop events**, swipe through pages, event press and long-press, grid press and long-press, press grid to create events, hold event to edit
 * Customizable styles
 * Multiple locale support
 
@@ -87,6 +87,8 @@ const MyComponent = () => (
 * **`RefreshComponent`** _(React.Component)_ - Component used when `isRefreshing` is `true`. Receives a `style` prop that must be passed down (sets the component position), for example: `MyRefreshControl = ({ style }) => <Text style={style}>loading...</Text>`. Defaults to an `<ActivityIndicator />` with default parameters (notice the `ActivityIndicator` default color in some devices may be white).
 * **`prependMostRecent`** _(Boolean)_ - If `true`, the horizontal prepending is done in the most recent dates. See [issue #39](https://github.com/hoangnm/react-native-week-view/issues/39) for more details. Default is `false`.
 * **`onDragEvent`** _(Function)_ - Callback when event item is dragged to another position, signature: `(event, newStartDate, newEndDate) => {}`. The `event` returns the event moved, and the `newStartDate` and `newEndDate` are `Date` objects with day and hour of the new position (precision up to minutes). In this callback you should trigger an update on the `events` prop (i.e. update your DB), with the updated information from the event. The events are draggable only if this callback is provided.
+* **`onEditEventEndDate`** _(Function)_ - Callback when an event is edited. To enable edit mode, press or long-press (see next prop), and edit the end hour by dragging the bottom border. Function signature: `(event, newEndDate) => {}`, the event edited and the `newEndDate` is a `Date` object. In this callback you should trigger an update on the `events` prop (i.e. update your DB), with the updated information from the event. The edit-mode is enabled only if this callback is provided.
+* **`editingInteraction`** _(String)_ - indicates interaction to enable editing mode, one of `"press"` or `"longPress"` (defaults to `"longPress"`).
 
 ### Event Object
 ```js

--- a/README.md
+++ b/README.md
@@ -174,7 +174,94 @@ addLocale('fr', {
 });
 ```
 
-## Other example usages
+## Example usages
+
+### User-event interactions:
+
+1. Drag and drop event
+2. Long press on the grid to create an event
+3. Edit an event by (a) long pressing, (b) dragging the bottom border
+
+```js
+class MyComponent extends React.Component {
+  state = {
+    events: [
+      // ...
+    ],
+  };
+
+  // (1) Drag and drop event
+  handleDragEvent = (event, newStartDate, newEndDate) => {
+    // Update the event in your DB with the new date and hour
+    this.setState({
+      events: [
+        ...this.state.events.filter(e => e.id !== event.id),
+        {
+          ...event,
+          startDate: newStartDate,
+          endDate: newEndDate,
+        },
+      ],
+    });
+  };
+
+  // (2) Long-press on grid to create event
+  handleCreateNewEvent = (event, startHour, date) => {
+    // Create a dummy event placed on date and startHour
+    const maxId = Math.max(...this.state.events.map(e => e.id));
+    const startDate = date;
+    startDate.setHours(startHour);
+    const endDate = new Date(startDate.getTime());
+    endDate.setHours(startDate.getHours() + 2);
+    const dummyEvent = {
+      id: maxId + 1,
+      description: 'New Event',
+      color: 'rgb(0, 200, 0)',
+      startDate,
+      endDate,
+    };
+
+    // You could open a modal or something else to fetch real data
+
+    // Update DB with the new event
+    this.setState({
+      events: [
+        ...this.state.events,
+        dummyEvent,
+      ],
+    });
+  };
+
+  // (3) Edit event
+  handleEditEventEndDate = (event, newEndDate) => {
+    // Update event in the DB
+    this.setState({
+      events: [
+        ...this.state.events.filter(e => e.id !== event.id),
+        {
+          ...event,
+          endDate: newEndDate,
+        },
+      ],
+    });
+  };
+
+  render() {
+    const { events } = this.state;
+    return (
+      <WeekView
+        events={events}
+        onDragEvent={this.handleDragEvent}
+        onGridLongPress={this.handleCreateNewEvent}
+        onEditEventEndDate={this.handleEditEventEndDate}
+        // ... other props
+      />
+    );
+  }
+}
+```
+
+
 
 ### Fixed week
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ addLocale('fr', {
 
 ## Example usages
 
-### User-event interactions:
+### Common user-event interactions:
 
 1. Drag and drop event
 2. Long press on the grid to create an event

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -34,6 +34,7 @@ local.properties
 node_modules/
 npm-debug.log
 yarn-error.log
+package-lock.json
 
 # BUCK
 buck-out/

--- a/example/App.js
+++ b/example/App.js
@@ -127,7 +127,8 @@ class App extends React.Component {
     });
   };
 
-  onEditEventEndDate = (event, newEndDate) => {
+  onEditEventEndDate = (oldEvent, newEndDate) => {
+    const event = this.state.events.find(e => e.id === oldEvent.id);
     this.setState({
       events: [
         ...this.state.events.filter(e => e.id !== event.id),

--- a/example/App.js
+++ b/example/App.js
@@ -107,6 +107,38 @@ class App extends React.Component {
     });
   };
 
+  onGridLongPress = (event, startHour, date) => {
+    const maxId = Math.max(...this.state.events.map(e => e.id));
+    const startDate = date;
+    startDate.setHours(startHour);
+    const endDate = new Date(startDate.getTime());
+    endDate.setHours(startDate.getHours() + 2);
+    this.setState({
+      events: [
+        ...this.state.events,
+        {
+          id: maxId + 1,
+          description: 'New Event',
+          color: 'rgb(0, 200, 0)',
+          startDate,
+          endDate,
+        },
+      ],
+    });
+  };
+
+  onEditEventEndDate = (event, newEndDate) => {
+    this.setState({
+      events: [
+        ...this.state.events.filter(e => e.id !== event.id),
+        {
+          ...event,
+          endDate: newEndDate,
+        },
+      ],
+    });
+  };
+
   render() {
     const {events, selectedDate} = this.state;
     return (
@@ -122,6 +154,7 @@ class App extends React.Component {
             numberOfDays={7}
             onEventPress={this.onEventPress}
             onGridClick={this.onGridClick}
+            onGridLongPress={this.onGridLongPress}
             headerStyle={styles.header}
             headerTextStyle={styles.headerText}
             hourTextStyle={styles.hourText}
@@ -134,6 +167,7 @@ class App extends React.Component {
             showTitle={!showFixedComponent}
             showNowLine
             onDragEvent={this.onDragEvent}
+            onEditEventEndDate={this.onEditEventEndDate}
             isRefreshing={false}
             RefreshComponent={MyRefreshComponent}
           />

--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint .",
-    "sync": "/usr/bin/rsync -v -a ../src ./node_modules/react-native-week-view/"
+    "sync": "/usr/bin/rsync -v -a ../src ../index.js ../package.json ./node_modules/react-native-week-view/"
   },
   "dependencies": {
     "react": "17.0.1",

--- a/src/Event/Event.js
+++ b/src/Event/Event.js
@@ -1,9 +1,10 @@
 import React, { useRef, useEffect, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { Animated, PanResponder, Text, TouchableOpacity } from 'react-native';
+import { Animated, PanResponder, Text, TouchableOpacity, View } from 'react-native';
 import styles from './Event.styles';
 
 const UPDATE_EVENT_ANIMATION_DURATION = 150;
+const EDITING_OPACITY = 0.8
 
 const hasMovedEnough = (gestureState) => {
   const { dx, dy } = gestureState;
@@ -18,10 +19,47 @@ const Event = ({
   EventComponent,
   containerStyle,
   onDrag,
+  onEditEndDate,
+  editingEventId,
+  onStartEditingEvent,
+  editingInteraction,
 }) => {
-  const isDragEnabled = !!onDrag;
+  const isEditing = onEditEndDate && editingEventId === event.id;
 
-  const isPressDisabled = !onPress && !onLongPress;
+  const isDragEnabled = !!onDrag && !isEditing;
+
+  const [onPressContainer, onLongPressContainer] = useMemo(() => {
+    // Case 1
+    const noEditEnabled = !onEditEndDate || !editingInteraction;
+    if (noEditEnabled) return [onPress, onLongPress];
+
+    // Case 2
+    const isEditingOtherEvent = !isEditing && editingEventId != null;
+    if (isEditingOtherEvent) return [onPress, onLongPress];
+
+    // Case 3
+    if (isEditing) {
+      // Any touch exits editing mode
+      const stopEditing = () => onStartEditingEvent(null);
+      return [stopEditing, stopEditing];
+    }
+
+    // Case 4
+    if (editingInteraction === 'press') return [onStartEditingEvent, onLongPress];
+
+    // Case 5
+    return [onPress, onStartEditingEvent]; // editingInteraction === 'longPress'
+  }, [
+    isEditing,
+    editingEventId,
+    onPress,
+    onLongPress,
+    onEditEndDate,
+    onStartEditingEvent,
+    editingInteraction,
+  ]);
+
+  const isPressDisabled = !onPressContainer && !onLongPressContainer;
 
   const onDragRelease = useCallback(
     (dx, dy) => {
@@ -39,10 +77,30 @@ const Event = ({
   const translatedByDrag = useRef(new Animated.ValueXY()).current;
   const currentWidth = useRef(new Animated.Value(position.width)).current;
   const currentLeft = useRef(new Animated.Value(position.left)).current;
+  const currentHeight = useRef(new Animated.Value(0)).current;
+
+  const onEditRelease = useCallback((position, dy) => {
+    if (!onEditEndDate) {
+      return;
+    }
+
+    const newY = position.top + position.height + dy;
+    if (newY <= position.top) {
+      currentHeight.setOffset(position.height);
+      currentHeight.setValue(0);
+      return;
+    }
+    onEditEndDate(event, newY);
+  }, [event, onEditEndDate]);
 
   useEffect(() => {
     translatedByDrag.setValue({ x: 0, y: 0 });
-    const { left, width } = position;
+    const { left, width, height } = position;
+
+    // No animation, only changes by dragging
+    currentHeight.setOffset(height);
+    currentHeight.setValue(0);
+
     const animations = [
       Animated.timing(currentWidth, {
         toValue: width,
@@ -58,7 +116,7 @@ const Event = ({
     Animated.parallel(animations).start();
   }, [position]);
 
-  const panResponder = useMemo(() => {
+  const containerPanResponder = useMemo(() => {
     return PanResponder.create({
       onStartShouldSetPanResponder: () => isDragEnabled,
       onStartShouldSetPanResponderCapture: () =>
@@ -90,6 +148,36 @@ const Event = ({
     });
   }, [onDragRelease, isDragEnabled, isPressDisabled]);
 
+  const editCirclePanResponder = useMemo(() =>
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => isEditing,
+      onStartShouldSetPanResponderCapture: () => isEditing,
+      onMoveShouldSetPanResponder: () => isEditing,
+      onMoveShouldSetPanResponderCapture: () => isEditing,
+      onPanResponderMove: Animated.event(
+        [
+          null,
+          {
+            dy: currentHeight,
+          },
+        ],
+        {
+          useNativeDriver: false,
+        },
+      ),
+      onPanResponderTerminationRequest: () => false,
+      onPanResponderRelease: (_, gestureState) => {
+        const { dy } = gestureState;
+        onEditRelease(position, dy);
+        onStartEditingEvent(null);
+      },
+      onPanResponderTerminate: () => {
+        currentHeight.setOffset(position.height);
+        currentHeight.setValue(0);
+        onStartEditingEvent(null);
+      },
+    }), [isEditing, position, onEditRelease, onStartEditingEvent]);
+
   return (
     <Animated.View
       style={[
@@ -97,21 +185,22 @@ const Event = ({
         {
           top: position.top,
           left: currentLeft,
-          height: position.height,
+          height: currentHeight,
           width: currentWidth,
           backgroundColor: event.color,
           transform: translatedByDrag.getTranslateTransform(),
         },
         containerStyle,
+        isEditing && { opacity: EDITING_OPACITY },
       ]}
       /* eslint-disable react/jsx-props-no-spreading */
-      {...panResponder.panHandlers}
+      {...containerPanResponder.panHandlers}
     >
       <TouchableOpacity
-        onPress={() => onPress && onPress(event)}
-        onLongPress={() => onLongPress && onLongPress(event)}
+        onPress={() => onPressContainer && onPressContainer(event)}
+        onLongPress={() => onLongPressContainer && onLongPressContainer(event)}
         style={styles.touchableContainer}
-        disabled={!onPress && !onLongPress}
+        disabled={isPressDisabled}
       >
         {EventComponent ? (
           <EventComponent event={event} position={position} />
@@ -119,6 +208,14 @@ const Event = ({
           <Text style={styles.description}>{event.description}</Text>
         )}
       </TouchableOpacity>
+      {isEditing && (
+        <View
+          style={styles.circle}
+          hitSlop={{ bottom: 10, left: 10, right: 10, top: 10 }}
+          /* eslint-disable react/jsx-props-no-spreading */
+          {...editCirclePanResponder.panHandlers}
+        />
+      )}
     </Animated.View>
   );
 };
@@ -146,6 +243,10 @@ Event.propTypes = {
   containerStyle: PropTypes.object,
   EventComponent: PropTypes.elementType,
   onDrag: PropTypes.func,
+  onEditEndDate: PropTypes.func,
+  editingEventId: PropTypes.number,
+  onStartEditingEvent: PropTypes.func,
+  editingInteraction: PropTypes.oneOf(['press', 'longPress']),
 };
 
 export default Event;

--- a/src/Event/Event.styles.js
+++ b/src/Event/Event.styles.js
@@ -1,12 +1,13 @@
 import { StyleSheet } from 'react-native';
 
+const circleSize = 15;
+
 const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     position: 'absolute',
     borderRadius: 0,
     flex: 1,
-    overflow: 'hidden',
   },
   touchableContainer: {
     flex: 1,
@@ -18,6 +19,16 @@ const styles = StyleSheet.create({
     color: '#fff',
     textAlign: 'center',
     fontSize: 15,
+  },
+  circle: {
+    position: 'absolute',
+    bottom: -circleSize / 2,
+    borderColor: 'black',
+    borderWidth: 1,
+    borderRadius: circleSize,
+    height: circleSize,
+    width: circleSize,
+    backgroundColor: 'white',
   },
 });
 

--- a/src/Events/Events.js
+++ b/src/Events/Events.js
@@ -229,6 +229,22 @@ class Events extends PureComponent {
     return moment(initialDate).add(dayIndex, 'days').isSame(today, 'day');
   };
 
+  onEditEventEndDate = (event, newY) => {
+    const { onEditEventEndDate } = this.props;
+    if (!onEditEventEndDate) {
+      return;
+    }
+    const { endDate } = event;
+
+    const newSeconds = this.yToHour(newY - CONTENT_OFFSET) * 3600;
+    const newEndDate = moment(endDate)
+      .startOf('day')
+      .seconds(newSeconds)
+      .toDate();
+
+    onEditEventEndDate(event, newEndDate);
+  };
+
   render() {
     const {
       eventsByDate,
@@ -245,6 +261,10 @@ class Events extends PureComponent {
       showNowLine,
       nowLineColor,
       onDragEvent,
+      onEditEventEndDate,
+      editingEventId,
+      onStartEditingEvent,
+      editingInteraction,
     } = this.props;
     const totalEvents = this.processEvents(
       eventsByDate,
@@ -292,6 +312,10 @@ class Events extends PureComponent {
                     EventComponent={EventComponent}
                     containerStyle={eventContainerStyle}
                     onDrag={onDragEvent && this.onDragEvent}
+                    onEditEndDate={onEditEventEndDate && this.onEditEventEndDate}
+                    editingEventId={editingEventId}
+                    onStartEditingEvent={onStartEditingEvent}
+                    editingInteraction={editingInteraction}
                   />
                 ))}
               </View>
@@ -321,6 +345,10 @@ Events.propTypes = {
   showNowLine: PropTypes.bool,
   nowLineColor: PropTypes.string,
   onDragEvent: PropTypes.func,
+  onEditEventEndDate: PropTypes.func,
+  editingEventId: PropTypes.number,
+  onStartEditingEvent: PropTypes.func,
+  editingInteraction: PropTypes.oneOf(['press', 'longPress']),
 };
 
 export default Events;

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -48,6 +48,7 @@ export default class WeekView extends Component {
       // currentMoment should always be the first date of the current page
       currentMoment: moment(initialDates[this.currentPageIndex]).toDate(),
       initialDates,
+      editingEventId: null,
     };
 
     setLocale(props.locale);
@@ -363,6 +364,21 @@ export default class WeekView extends Component {
     index,
   });
 
+  startEditingEvent = (event) => {
+    if (!this.props.onEditEventEndDate) {
+      return;
+    }
+
+    const { editingEventId } = this.state;
+    if (event != null && editingEventId != null) {
+      return;
+    }
+
+    this.setState({
+      editingEventId: event && event.id,
+    });
+  };
+
   render() {
     const {
       showTitle,
@@ -388,10 +404,12 @@ export default class WeekView extends Component {
       showNowLine,
       nowLineColor,
       onDragEvent,
+      onEditEventEndDate,
+      editingInteraction,
       isRefreshing,
       RefreshComponent,
     } = this.props;
-    const { currentMoment, initialDates } = this.state;
+    const { currentMoment, initialDates, editingEventId } = this.state;
     const times = this.calculateTimes(timeStep, formatTimeLabel);
     const eventsByDate = this.sortEventsByDate(events);
     const horizontalInverted =
@@ -483,6 +501,10 @@ export default class WeekView extends Component {
                     showNowLine={showNowLine}
                     nowLineColor={nowLineColor}
                     onDragEvent={onDragEvent}
+                    onEditEventEndDate={onEditEventEndDate}
+                    editingEventId={editingEventId}
+                    onStartEditingEvent={this.startEditingEvent}
+                    editingInteraction={editingInteraction}
                   />
                 );
               }}
@@ -545,6 +567,8 @@ WeekView.propTypes = {
   onDragEvent: PropTypes.func,
   isRefreshing: PropTypes.bool,
   RefreshComponent: PropTypes.elementType,
+  onEditEventEndDate: PropTypes.func,
+  editingInteraction: PropTypes.oneOf(['press', 'longPress']),
 };
 
 WeekView.defaultProps = {
@@ -559,4 +583,5 @@ WeekView.defaultProps = {
   rightToLeft: false,
   prependMostRecent: false,
   RefreshComponent: ActivityIndicator,
+  editingInteraction: 'longPress',
 };


### PR DESCRIPTION
Fixes #58. This PR needs bug fix #152, so marked as draft for now

![feature-drag-and-edit](https://user-images.githubusercontent.com/20805451/143510597-281d0b5e-10da-41e3-8f5e-a4506ea3b545.gif)

* Hold an event to enable "edit-mode" --> appears circle and opacity is reduced --> move circle to change `endDate`
* Edit mode ends when (a) finish editing; or (b) press again in the same event
* Only one event can be edited at the same time
* I added some code samples to the README
* The `Event` component is getting more complex, and probably getting less efficient. Improvements welcomed!

Update: we are fully solving drag and drop before addressing this feature again