### PR TITLE
Add gridRowStyle and gridColumnStyle props

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ const MyComponent = () => (
 * **`prependMostRecent`** _(Boolean)_ - If `true`, the horizontal prepending is done in the most recent dates. See [issue #39](https://github.com/hoangnm/react-native-week-view/issues/39) for more details. Default is `false`.
 * **`onDragEvent`** _(Function)_ - Callback when event item is dragged to another position, signature: `(event, newStartDate, newEndDate) => {}`. The `event` returns the event moved, and the `newStartDate` and `newEndDate` are `Date` objects with day and hour of the new position (precision up to minutes). In this callback you should trigger an update on the `events` prop (i.e. update your DB), with the updated information from the event. The events are draggable only if this callback is provided.
 * Grid border styling props:
-  * **`gridRow`** _(Object)_ - `{ borderTopWidth: <width>, borderColor: <color> }` to customize width and color of horizontal lines
-  * **`gridColumn`** _(Object)_ - `{ borderLeftWidth: <width>, borderColor: <color> }` to customize width and color of vertical lines
+  * **`gridRowStyle`** _(Object)_ - `{ borderTopWidth: <width>, borderColor: <color> }` to customize width and color of horizontal lines
+  * **`gridColumnStyle`** _(Object)_ - `{ borderLeftWidth: <width>, borderColor: <color> }` to customize width and color of vertical lines
 
 ### Event Object
 ```js

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ const MyComponent = () => (
 * **`RefreshComponent`** _(React.Component)_ - Component used when `isRefreshing` is `true`. Receives a `style` prop that must be passed down (sets the component position), for example: `MyRefreshControl = ({ style }) => <Text style={style}>loading...</Text>`. Defaults to an `<ActivityIndicator />` with default parameters (notice the `ActivityIndicator` default color in some devices may be white).
 * **`prependMostRecent`** _(Boolean)_ - If `true`, the horizontal prepending is done in the most recent dates. See [issue #39](https://github.com/hoangnm/react-native-week-view/issues/39) for more details. Default is `false`.
 * **`onDragEvent`** _(Function)_ - Callback when event item is dragged to another position, signature: `(event, newStartDate, newEndDate) => {}`. The `event` returns the event moved, and the `newStartDate` and `newEndDate` are `Date` objects with day and hour of the new position (precision up to minutes). In this callback you should trigger an update on the `events` prop (i.e. update your DB), with the updated information from the event. The events are draggable only if this callback is provided.
+* Grid border styling props:
+  * **`gridRow`** _(Object)_ - `{ borderTopWidth: <width>, borderColor: <color> }` to customize width and color of horizontal lines
+  * **`gridColumn`** _(Object)_ - `{ borderLeftWidth: <width>, borderColor: <color> }` to customize width and color of vertical lines
 
 ### Event Object
 ```js

--- a/example/App.js
+++ b/example/App.js
@@ -132,6 +132,8 @@ class App extends React.Component {
             headerTextStyle={styles.headerText}
             hourTextStyle={styles.hourText}
             eventContainerStyle={styles.eventContainer}
+            gridColumnStyle={styles.gridColumn}
+            gridRowStyle={styles.gridRow}
             formatDateHeader={showFixedComponent ? 'ddd' : 'ddd DD'}
             hoursInDisplay={12}
             timeStep={60}
@@ -167,6 +169,14 @@ const styles = StyleSheet.create({
   eventContainer: {
     borderWidth: 1,
     borderColor: 'black',
+  },
+  gridRow: {
+    borderTopWidth: 1,
+    borderColor: '#E9EDF0',
+  },
+  gridColumn: {
+    borderLeftWidth: 1,
+    borderColor: '#E9EDF0',
   },
 });
 

--- a/src/Events/Events.js
+++ b/src/Events/Events.js
@@ -250,6 +250,8 @@ class Events extends PureComponent {
       onEventPress,
       onEventLongPress,
       eventContainerStyle,
+      gridRowStyle,
+      gridColumnStyle,
       EventComponent,
       rightToLeft,
       hoursInDisplay,
@@ -265,6 +267,7 @@ class Events extends PureComponent {
       hoursInDisplay,
       rightToLeft,
     );
+    const timeSlotHeight = getTimeLabelHeight(hoursInDisplay, timeStep);
 
     return (
       <View style={styles.container}>
@@ -273,11 +276,10 @@ class Events extends PureComponent {
             key={time}
             style={[
               styles.timeRow,
-              { height: getTimeLabelHeight(hoursInDisplay, timeStep) },
+              { height: timeSlotHeight },
+              gridRowStyle,
             ]}
-          >
-            <View style={styles.timeLabelLine} />
-          </View>
+          />
         ))}
         <View style={styles.eventsContainer}>
           {totalEvents.map((eventsInSection, dayIndex) => (
@@ -286,7 +288,7 @@ class Events extends PureComponent {
               onLongPress={(e) => this.onGridTouch(e, dayIndex, true)}
               key={dayIndex}
             >
-              <View style={styles.eventsColumn}>
+              <View style={[styles.eventsColumn, gridColumnStyle]}>
                 {showNowLine && this.isToday(dayIndex) && (
                   <NowLine
                     color={nowLineColor}
@@ -315,6 +317,17 @@ class Events extends PureComponent {
   }
 }
 
+const GridRowPropType = PropTypes.shape({
+  borderColor: PropTypes.string,
+  borderTopWidth: PropTypes.number,
+});
+
+const GridColumnPropType = PropTypes.shape({
+  borderColor: PropTypes.string,
+  borderLeftWidth: PropTypes.number,
+});
+
+
 Events.propTypes = {
   numberOfDays: PropTypes.oneOf(availableNumberOfDays).isRequired,
   eventsByDate: PropTypes.objectOf(PropTypes.arrayOf(Event.propTypes.event))
@@ -328,6 +341,8 @@ Events.propTypes = {
   onGridClick: PropTypes.func,
   onGridLongPress: PropTypes.func,
   eventContainerStyle: PropTypes.object,
+  gridRowStyle: GridRowPropType,
+  gridColumnStyle: GridColumnPropType,
   EventComponent: PropTypes.elementType,
   rightToLeft: PropTypes.bool,
   showNowLine: PropTypes.bool,

--- a/src/Events/Events.styles.js
+++ b/src/Events/Events.styles.js
@@ -11,13 +11,9 @@ const styles = StyleSheet.create({
   },
   timeRow: {
     flex: 0,
-  },
-  timeLabelLine: {
-    height: 1,
-    backgroundColor: GREY_COLOR,
-    position: 'absolute',
-    right: 0,
-    left: 0,
+    borderTopWidth: 1,
+    borderColor: GREY_COLOR,
+    backgroundColor: 'transparent',
   },
   eventsColumn: {
     flex: 1,

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -370,6 +370,8 @@ export default class WeekView extends Component {
       headerStyle,
       headerTextStyle,
       hourTextStyle,
+      gridRowStyle,
+      gridColumnStyle,
       eventContainerStyle,
       TodayHeaderComponent,
       formatDateHeader,
@@ -479,6 +481,8 @@ export default class WeekView extends Component {
                     timeStep={timeStep}
                     EventComponent={EventComponent}
                     eventContainerStyle={eventContainerStyle}
+                    gridRowStyle={gridRowStyle}
+                    gridColumnStyle={gridColumnStyle}
                     rightToLeft={rightToLeft}
                     showNowLine={showNowLine}
                     nowLineColor={nowLineColor}
@@ -528,6 +532,8 @@ WeekView.propTypes = {
   headerTextStyle: PropTypes.object,
   hourTextStyle: PropTypes.object,
   eventContainerStyle: PropTypes.object,
+  gridRowStyle: Events.propTypes.gridRowStyle,
+  gridColumnStyle: Events.propTypes.gridColumnStyle,
   selectedDate: PropTypes.instanceOf(Date).isRequired,
   locale: PropTypes.string,
   hoursInDisplay: PropTypes.number,


### PR DESCRIPTION
Fixes #43, fixes #138, fixes #156

* Add `gridRowStyle` and `gridColumnStyle` props, to modify grid horizontal and vertical lines (separated). Usage:
  ```js
  gridRowStyle={{ borderTopWidth: <width>, borderColor: <color> }} // horizontal lines width and color
  gridColumnStyle={{ borderLeftWidth: <width>, borderColor: <color> }} // vertical lines width and color
  ```
* I removed an extra `<View/>` element, for simplicity

I'm not sure the props I chose are the best option, lmk if you think there are better options