### PR TITLE
Refactor: compute WeekView width dinamically

### DIFF
--- a/src/Events/Events.js
+++ b/src/Events/Events.js
@@ -156,8 +156,8 @@ const getEventsWithPosition = (
 };
 
 const processEvents = (
-  eventsByDate, initialDate, numberOfDays, dayWidth, hoursInDisplay, rightToLeft,
-  beginAgendaAt,
+  eventsByDate, initialDate, numberOfDays, dayWidth, hoursInDisplay,
+  rightToLeft, beginAgendaAt,
 ) => {
   // totalEvents stores events in each day of numberOfDays
   // example: [[event1, event2], [event3, event4], [event5]], each child array
@@ -191,27 +191,7 @@ class Events extends PureComponent {
     return fullWidth / numberOfDays;
   };
 
-  processEvents = memoizeOne(
-    (eventsByDate, initialDate, numberOfDays, hoursInDisplay, rightToLeft) => {
-      // totalEvents stores events in each day of numberOfDays
-      // example: [[event1, event2], [event3, event4], [event5]], each child array
-      // is events for specific day in range
-      const dates = calculateDaysArray(initialDate, numberOfDays, rightToLeft);
-      const totalEvents = dates.map((date) => {
-        const dateStr = date.format(DATE_STR_FORMAT);
-        return eventsByDate[dateStr] || [];
-      });
-
-      const regularItemWidth = this.getEventItemWidth();
-
-      const totalEventsWithPosition = getEventsWithPosition(
-        totalEvents,
-        regularItemWidth,
-        hoursInDisplay,
-      );
-      return totalEventsWithPosition;
-    },
-  );
+  processEvents = memoizeOne(processEvents);
 
   onGridTouch = (event, dayIndex, longPress) => {
     const { initialDate, onGridClick, onGridLongPress } = this.props;

--- a/src/Events/Events.styles.js
+++ b/src/Events/Events.styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { CONTAINER_WIDTH, CONTENT_OFFSET } from '../utils';
+import { CONTENT_OFFSET } from '../utils';
 
 const GREY_COLOR = '#E9EDF0';
 
@@ -7,7 +7,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     paddingTop: CONTENT_OFFSET,
-    width: CONTAINER_WIDTH,
   },
   timeRow: {
     flex: 0,

--- a/src/Times/Times.js
+++ b/src/Times/Times.js
@@ -4,10 +4,17 @@ import { View, Text } from 'react-native';
 import styles from './Times.styles';
 import { getTimeLabelHeight } from '../utils';
 
-const Times = ({ times, hoursInDisplay, timeStep, textStyle }) => {
+const Times = ({
+  times, hoursInDisplay, timeStep, textStyle, width,
+}) => {
   const height = getTimeLabelHeight(hoursInDisplay, timeStep);
   return (
-    <View style={styles.columnContainer}>
+    <View
+      style={[
+        styles.columnContainer,
+        { width },
+      ]}
+    >
       {times.map((time) => (
         <View key={time} style={[styles.label, { height }]}>
           <Text style={[styles.text, textStyle]}>{time}</Text>
@@ -22,6 +29,7 @@ Times.propTypes = {
   hoursInDisplay: PropTypes.number.isRequired,
   timeStep: PropTypes.number.isRequired,
   textStyle: Text.propTypes.style,
+  width: PropTypes.number.isRequired,
 };
 
 export default React.memo(Times);

--- a/src/Times/Times.styles.js
+++ b/src/Times/Times.styles.js
@@ -3,7 +3,6 @@ import { StyleSheet } from 'react-native';
 const styles = StyleSheet.create({
   columnContainer: {
     paddingTop: 10,
-    width: 60,
   },
   label: {
     flex: -1,

--- a/src/Title/Title.js
+++ b/src/Title/Title.js
@@ -13,7 +13,7 @@ const getFontSizeHeader = (numberOfDays) => {
 };
 
 const Title = ({
-  style, showTitle, numberOfDays, selectedDate, textStyle, onMonthPress,
+  style, showTitle, numberOfDays, selectedDate, textStyle, onMonthPress, width,
 }) => {
   if (!showTitle) {
     return <View style={[styles.title, style]}></View>
@@ -21,7 +21,7 @@ const Title = ({
   const formattedMonth = getCurrentMonth(selectedDate);
   return (
     <TouchableOpacity
-      style={[styles.title, style]}
+      style={[styles.title, { width }, style]}
       onPress={() => onMonthPress && onMonthPress(selectedDate, formattedMonth)}
       disabled={!onMonthPress}
     >
@@ -47,6 +47,7 @@ Title.propTypes = {
   style: PropTypes.object,
   textStyle: PropTypes.object,
   onMonthPress: PropTypes.func,
+  width: PropTypes.number.isRequired,
 };
 
 export default React.memo(Title);

--- a/src/Title/Title.styles.js
+++ b/src/Title/Title.styles.js
@@ -4,7 +4,6 @@ const styles = StyleSheet.create({
   title: {
     justifyContent: 'center',
     alignItems: 'center',
-    width: 60,
     borderTopWidth: 1,
   },
 });

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -419,7 +419,6 @@ export default class WeekView extends Component {
       (prependMostRecent && !rightToLeft) ||
       (!prependMostRecent && rightToLeft);
 
-    // Update dimensions
     this.dimensions = this.updateDimensions(numberOfDays);
     const {
       pageWidth,

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -23,6 +23,7 @@ import {
   availableNumberOfDays,
   setLocale,
   CONTAINER_WIDTH,
+  TIMES_WIDTH,
 } from '../utils';
 
 const MINUTES_IN_DAY = 60 * 24;
@@ -403,6 +404,10 @@ export default class WeekView extends Component {
       (prependMostRecent && !rightToLeft) ||
       (!prependMostRecent && rightToLeft);
 
+    const pageWidth = CONTAINER_WIDTH;
+    const timeLabelsWidth = TIMES_WIDTH;
+    const dayWidth = pageWidth / numberOfDays;
+
     return (
       <View style={styles.container}>
         <View style={styles.headerContainer}>
@@ -460,6 +465,7 @@ export default class WeekView extends Component {
               textStyle={hourTextStyle}
               hoursInDisplay={hoursInDisplay}
               timeStep={timeStep}
+              width={timeLabelsWidth}
             />
             <VirtualizedList
               data={initialDates}
@@ -493,6 +499,8 @@ export default class WeekView extends Component {
                     showNowLine={showNowLine}
                     nowLineColor={nowLineColor}
                     onDragEvent={onDragEvent}
+                    pageWidth={pageWidth}
+                    dayWidth={dayWidth}
                   />
                 );
               }}

--- a/src/WeekView/WeekView.styles.js
+++ b/src/WeekView/WeekView.styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { CONTAINER_WIDTH, CONTAINER_HEIGHT } from '../utils';
+import { CONTAINER_HEIGHT } from '../utils';
 
 const styles = StyleSheet.create({
   container: {
@@ -16,12 +16,10 @@ const styles = StyleSheet.create({
     height: 50,
     justifyContent: 'center',
     alignItems: 'center',
-    width: CONTAINER_WIDTH,
   },
   loadingSpinner: {
     position: 'absolute',
     top: CONTAINER_HEIGHT / 2,
-    right: CONTAINER_WIDTH / 2,
     zIndex: 2,
   },
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,32 @@
 import { Dimensions } from 'react-native';
 import moment from 'moment';
 
-const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 export const CONTENT_OFFSET = 16;
 export const CONTAINER_HEIGHT = SCREEN_HEIGHT - 60;
-export const TIMES_WIDTH = 60;
-export const CONTAINER_WIDTH = SCREEN_WIDTH - TIMES_WIDTH;
 export const DATE_STR_FORMAT = 'YYYY-MM-DD';
 export const availableNumberOfDays = [1, 3, 5, 7];
+
+const TIMES_WIDTH_PERCENTAGE = 18;
+const PAGE_WIDTH_PERCENTAGE = (100 - TIMES_WIDTH_PERCENTAGE) / 100;
+
+export const computeWeekViewDimensions = (numberOfDays) => {
+  const { width: screenWidth } = Dimensions.get('window');
+
+  // Each day must have an equal width (integer pixels)
+  const dayWidth = Math.floor(screenWidth * PAGE_WIDTH_PERCENTAGE / numberOfDays);
+  const pageWidth = numberOfDays * dayWidth;
+
+  // Fill the full screen
+  const timeLabelsWidth = screenWidth - pageWidth;
+
+  const dimensions = {
+    pageWidth,
+    timeLabelsWidth,
+    dayWidth,
+  };
+  return dimensions;
+}
 
 export const minutesToYDimension = (hoursInDisplay, minutes) => {
   const minutesInDisplay = 60 * hoursInDisplay;

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,8 @@ import moment from 'moment';
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 export const CONTENT_OFFSET = 16;
 export const CONTAINER_HEIGHT = SCREEN_HEIGHT - 60;
-export const CONTAINER_WIDTH = SCREEN_WIDTH - 60;
+export const TIMES_WIDTH = 60;
+export const CONTAINER_WIDTH = SCREEN_WIDTH - TIMES_WIDTH;
 export const DATE_STR_FORMAT = 'YYYY-MM-DD';
 export const availableNumberOfDays = [1, 3, 5, 7];
 


### PR DESCRIPTION
Main changes:

* Remove hard-coded `CONTAINER_WIDTH` variable
* Calculate dynamically `dimensions = { dayWidth, pageWidth, timeLabelsWidth }` to define the widths of the views

This refactor will allow solving later:

* issues #128, #185, and #186 **(already solved in upcoming PRs)**
* responsiveness (#38, #142) **(in the future)**