### PR TITLE
Bug: Incorrect headerTextStyle type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -202,7 +202,7 @@ export interface WeekViewProps {
 
   // Style props
   headerStyle?: StyleProp<ViewStyle>;
-  headerTextStyle?: StyleProp<ViewStyle>;
+  headerTextStyle?: StyleProp<TextStyle>;
   hourTextStyle?: StyleProp<TextStyle>;
   eventContainerStyle?: StyleProp<ViewStyle>;
 


### PR DESCRIPTION
headerTextStyle has the wrong type `StyleProp<ViewStyle>` when it is passed to a `<Text>` element