### PR TITLE
Chore: add minimal horizontal-scroll test

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -104,9 +104,9 @@ const onDayPress = (date, formattedDate) => {
   console.log('Day: ', date, formattedDate);
 };
 
-const onTimeScrolled = date => {
-  console.log(`New start time: ${date.getHours()}:${date.getMinutes()}`);
-};
+const onSwipeNext = d => console.log('Swipe next', d.toDateString());
+const onSwipePrev = d => console.log('Swipe prev', d.toDateString());
+const onTimeScrolled = d => console.log('Time scrolled', d.toTimeString());
 
 // Use this to manually debug navigate through dates
 // eslint-disable-next-line no-unused-vars
@@ -219,6 +219,8 @@ const App = ({}) => {
           onDayPress={onDayPress}
           onMonthPress={onMonthPress}
           onTimeScrolled={onTimeScrolled}
+          onSwipeNext={onSwipeNext}
+          onSwipePrev={onSwipePrev}
           editingEvent={editingEvent}
           onEditEvent={onEditEvent}
           editEventConfig={EDIT_EVENT_CONFIG}

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     ],
     "setupFilesAfterEnv": [
       "jest-extended/all",
-      "@testing-library/jest-native/extend-expect"
+      "@testing-library/jest-native/extend-expect",
+      "<rootDir>/src/__tests__/expect.js"
     ],
     "transformIgnorePatterns": [
       "node_modules/(?!(jest-)?react-native|@react-native|@react-navigation)"

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -40,6 +40,12 @@ import {
   PageStartAtOptionsPropType,
   DragEventConfigPropType,
 } from '../utils/types';
+import {
+  PAGES_OFFSET,
+  calculatePagesDates,
+  getRawDayOffset,
+  DEFAULT_WINDOW_SIZE,
+} from '../utils/pages';
 
 /** For some reason, this sign is necessary in all cases. */
 const VIEW_OFFSET_SIGN = -1;
@@ -63,56 +69,6 @@ const calculateTimesArray = (
   }
 
   return times;
-};
-
-const getRawDayOffset = (newDayOffset, options = {}) => {
-  const { left: distanceToLeft = null } = options || {};
-  if (distanceToLeft != null) {
-    // the user wants to see targetDate at <distanceToLeft> from the edge
-    return newDayOffset - distanceToLeft;
-  }
-  return newDayOffset;
-};
-
-const getPageStartDate = (
-  selectedDate,
-  numberOfDays,
-  pageStartAtOptions = {},
-) => {
-  const { left: distanceToLeft = null, weekday = null } =
-    pageStartAtOptions || {};
-  if (distanceToLeft != null) {
-    // the user wants to see selectedDate at <distanceToLeft> from the left edge
-    return moment(selectedDate).subtract(distanceToLeft, 'day');
-  }
-  if (weekday != null) {
-    const date = moment(selectedDate);
-    return date.subtract(
-      // Ensure centralDate is before currentMoment
-      (date.day() + numberOfDays - weekday) % numberOfDays,
-      'days',
-    );
-  }
-  return moment(selectedDate);
-};
-
-// FlatList configuration
-const PAGES_OFFSET = 2;
-const DEFAULT_WINDOW_SIZE = PAGES_OFFSET * 2 + 1;
-
-const calculatePagesDates = (
-  selectedDate,
-  numberOfDays,
-  pageStartAt,
-  prependMostRecent,
-) => {
-  const initialDates = [];
-  const centralDate = getPageStartDate(selectedDate, numberOfDays, pageStartAt);
-  for (let i = -PAGES_OFFSET; i <= PAGES_OFFSET; i += 1) {
-    const initialDate = moment(centralDate).add(numberOfDays * i, 'd');
-    initialDates.push(initialDate.format(DATE_STR_FORMAT));
-  }
-  return prependMostRecent ? initialDates.reverse() : initialDates;
 };
 
 export default class WeekView extends Component {

--- a/src/WeekView/WeekView.js
+++ b/src/WeekView/WeekView.js
@@ -503,11 +503,7 @@ export default class WeekView extends Component {
         onSwipePrev: onSwipeToThePast,
         onSwipeNext: onSwipeToTheFuture,
       } = this.props;
-      const movedForward = movedDays > 0;
-      const callback =
-        this.isAppendingTheFuture() === movedForward
-          ? onSwipeToTheFuture
-          : onSwipeToThePast;
+      const callback = movedDays > 0 ? onSwipeToTheFuture : onSwipeToThePast;
       if (callback) {
         callback(newMoment);
       }

--- a/src/__tests__/WeekView/horizontalSwipe.test.js
+++ b/src/__tests__/WeekView/horizontalSwipe.test.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Dimensions } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import WeekView from '../../WeekView/WeekView';
+import { computeHorizontalDimensions } from '../../utils/dimensions';
+import { PAGES_OFFSET, DEFAULT_WINDOW_SIZE } from '../../utils/pages';
+
+/** Utility function */
+const addDays = (date, nDays) => {
+  const newDate = new Date(date);
+  newDate.setDate(date.getDate() + nDays);
+  return newDate;
+};
+
+/**
+ * FIXME: this test is somewhat limited, it requires
+ * knowing the scroll-dimensions (contentWidth, layoutWidth, etc)
+ * to perform the scroll.
+ * Ideally, we would use something like pointer-events for react
+ * (https://testing-library.com/docs/user-event/pointer), but it does
+ * not exist for react-native (AFAIK).
+ * */
+describe('Swiping pages', () => {
+  const { width: SCREEN_WIDTH } = Dimensions.get('window');
+
+  const getScrollDimensions = (numberOfDays) => {
+    const { pageWidth } = computeHorizontalDimensions(
+      SCREEN_WIDTH,
+      numberOfDays,
+    );
+
+    return {
+      pageWidth,
+      contentWidth: pageWidth * DEFAULT_WINDOW_SIZE,
+      layoutWidth: pageWidth,
+      initialXPosition: pageWidth * PAGES_OFFSET,
+    };
+  };
+
+  const selectedDate = new Date(2022, 9, 12);
+  const events = [
+    {
+      id: 34,
+      startDate: new Date(2022, 9, 12, 10),
+      endDate: new Date(2022, 9, 12, 12),
+      description: 'some event',
+    },
+    {
+      id: 91,
+      startDate: new Date(2022, 9, 13, 11),
+      endDate: new Date(2022, 9, 13, 13, 15),
+      description: 'other event',
+    },
+  ];
+
+  const renderGridAndFireScroll = (props, nextOrPrevDirection) => {
+    const { getByHintText } = render(
+      <WeekView
+        events={events}
+        selectedDate={selectedDate}
+        hoursInDisplay={24}
+        startHour={0}
+        pageStartAt={{ left: 0 }}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+      />,
+    );
+    const grid = getByHintText('Grid with horizontal scroll');
+
+    const {
+      initialXPosition,
+      pageWidth,
+      contentWidth,
+      layoutWidth,
+    } = getScrollDimensions(props.numberOfDays || 7);
+
+    const horizontalInverted = props.rightToLeft !== props.prependMostRecent;
+    const scrollDirection = nextOrPrevDirection * (horizontalInverted ? -1 : 1);
+
+    fireEvent(grid, 'onMomentumScrollBegin');
+    fireEvent(grid, 'onMomentumScrollEnd', {
+      nativeEvent: {
+        /**
+         * NOTE: The target position is set with respect to the initial position,
+         * this method:
+         * --> can be used to swipe only one page from the initial position,
+         * --> cannot be used to swipe multiple times or multiple pages!
+         */
+        contentOffset: {
+          x: initialXPosition + pageWidth * scrollDirection,
+        },
+        contentSize: {
+          width: contentWidth,
+        },
+        layoutMeasurement: {
+          width: layoutWidth,
+        },
+      },
+    });
+  };
+
+  describe.each([
+    [3, {}],
+    [5, {}],
+    [5, { prependMostRecent: true }],
+    [7, {}],
+  ])('with %d days and props %p', (numberOfDays, moreProps) => {
+    it.each([
+      ['prev', 'onSwipePrev', 'onSwipeNext', -1],
+      ['next', 'onSwipeNext', 'onSwipePrev', 1],
+    ])(
+      'when swiping %s, calls %s once, with the correct date',
+      (_, target, nonTarget, direction) => {
+        const mockProps = {
+          numberOfDays,
+          ...(moreProps || {}),
+          onSwipePrev: jest.fn(),
+          onSwipeNext: jest.fn(),
+        };
+        renderGridAndFireScroll(mockProps, direction);
+
+        expect(mockProps[nonTarget]).not.toHaveBeenCalled();
+
+        const newPageDate = addDays(selectedDate, direction * numberOfDays);
+        const callback = mockProps[target];
+        expect(callback).toHaveBeenCalledOnce();
+        expect(callback).toHaveBeenCalledWith(
+          expect.toBeSameDayAs(newPageDate),
+        );
+      },
+    );
+  });
+});

--- a/src/__tests__/expect.js
+++ b/src/__tests__/expect.js
@@ -1,0 +1,31 @@
+/** Custom expect functions. */
+expect.extend({
+  toBeSameDayAs(received, expected) {
+    if (!(expected instanceof Date)) {
+      throw new Error(`${expected} must be a valid date`);
+    }
+    if (!(received instanceof Date)) {
+      return {
+        pass: false,
+        message: () => `Expected ${received} to be a valid date`,
+      };
+    }
+
+    const same =
+      received.getUTCFullYear() === expected.getUTCFullYear() &&
+      received.getUTCMonth() === expected.getUTCMonth() &&
+      received.getUTCDate() === expected.getUTCDate();
+
+    return same
+      ? {
+          pass: true,
+          message: () =>
+            `Expected ${received} to not be the same day as ${expected}`,
+        }
+      : {
+          pass: false,
+          message: () =>
+            `Expected ${received} to be the same day as ${expected}`,
+        };
+  },
+});

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -9,3 +9,7 @@ jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
 
 // Needed when using setTimeout (when showNowLine=true)
 jest.useFakeTimers();
+
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () => ({
+  runAfterInteractions: jest.fn((task) => task()),
+}));

--- a/src/utils/pages.js
+++ b/src/utils/pages.js
@@ -1,0 +1,54 @@
+/** Handle horizontal pages. */
+import moment from 'moment';
+import { DATE_STR_FORMAT } from './dates';
+
+// FlatList configuration
+export const PAGES_OFFSET = 2;
+export const DEFAULT_WINDOW_SIZE = PAGES_OFFSET * 2 + 1;
+
+export const getRawDayOffset = (newDayOffset, options = {}) => {
+  const { left: distanceToLeft = null } = options || {};
+  if (distanceToLeft != null) {
+    // the user wants to see targetDate at <distanceToLeft> from the edge
+    return newDayOffset - distanceToLeft;
+  }
+  return newDayOffset;
+};
+
+const getPageStartDate = (
+  selectedDate,
+  numberOfDays,
+  pageStartAtOptions = {},
+) => {
+  const { left: distanceToLeft = null, weekday = null } =
+    pageStartAtOptions || {};
+  if (distanceToLeft != null) {
+    // the user wants to see selectedDate at <distanceToLeft> from the left edge
+    return moment(selectedDate).subtract(distanceToLeft, 'day');
+  }
+  if (weekday != null) {
+    const date = moment(selectedDate);
+    return date.subtract(
+      // Ensure centralDate is before currentMoment
+      (date.day() + numberOfDays - weekday) % numberOfDays,
+      'days',
+    );
+  }
+  return moment(selectedDate);
+};
+
+/** Compute an array of dates representing pages. */
+export const calculatePagesDates = (
+  selectedDate,
+  numberOfDays,
+  pageStartAt,
+  prependMostRecent,
+) => {
+  const initialDates = [];
+  const centralDate = getPageStartDate(selectedDate, numberOfDays, pageStartAt);
+  for (let i = -PAGES_OFFSET; i <= PAGES_OFFSET; i += 1) {
+    const initialDate = moment(centralDate).add(numberOfDays * i, 'd');
+    initialDates.push(initialDate.format(DATE_STR_FORMAT));
+  }
+  return prependMostRecent ? initialDates.reverse() : initialDates;
+};


### PR DESCRIPTION
* Add a test for horizontal swiping
  * having this test should be useful for fixing #259 and improving overall performance
  * has limitations (see comments)
* Fix small bug when `prependMostRecent: true` (onSwipeNext and onSwipePrev calls were swapped)
* Refactor code into `utils/pages.js`