### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "peerDependencies": {
     "react": ">=16.8.0",
-    "react-native": "^0.60.0",
+    "react-native": "^0.70.0",
     "react-native-gesture-handler": "^2.3.2",
     "react-native-reanimated": "^2.4.1"
   },


### PR DESCRIPTION
When running "npm install" with react-native-week-view 0.28.0 and react-native ^0.70.0 I am having a peer dependency error.  If updating your peer dependencies to 0.70.0 is safe, it seems to fix the my dependency problem.  Not sure if the react-native version in "devDependencies" should or could be updated.  Or if this is not safe, maybe there is another way you know I can resolve the problem?  

[stderr] npm ERR! Could not resolve dependency:
[stderr] npm ERR! peer react-native@"^0.60.0" from react-native-week-view@0.28.0 [stderr] npm ERR! node_modules/react-native-week-view
[stderr] npm ERR!   react-native-week-view@"^0.28.0" from the root project

Thanks, Dana