### PR TITLE
Update peer-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "typescript": "^4.8.3"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-native": "^0.60.0",
+    "react": "*",
+    "react-native": "*",
     "react-native-gesture-handler": "^2.3.2",
     "react-native-reanimated": "^2.4.1"
   },


### PR DESCRIPTION
Replaces #294 

Other packages use `react-native: "*"` as well